### PR TITLE
Remove current_course in the listing of team members

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -6,11 +6,7 @@ controller("staffController", ["$scope", "$http", function($scope, $http) {
   $scope.filter  = ""
 
   $scope.title_for = function(member) {
-    if (member.current_course) {
-      return member.current_course.topic
-    } else {
-      return member.title
-    }
+    return member.title
   }
 
   $scope.toggleSort = function(field) {


### PR DESCRIPTION
![iron_directory](https://cloud.githubusercontent.com/assets/123075/12961298/4266307e-d005-11e5-898e-c5d2c4287f13.png)

Since current_course is a bit old (mine is 2015 and wrong), let's just display the title from slack.
